### PR TITLE
Fix #8: Bildeinfügen in den Produktbeschreibungen funktioniert nicht

### DIFF
--- a/classes/app/catalogue.php
+++ b/classes/app/catalogue.php
@@ -406,11 +406,8 @@ class Catalogue {
         if($writeEntities === true){
             $string = htmlspecialchars($string);
         }
-        if(get_magic_quotes_gpc() === 1){
-            $string  = rtrim(stripslashes($string));
-        }
 
-        return addslashes($string);
+        return addcslashes($string, '\'\\');
     }
 
     function addProduct($product){

--- a/classes/app/product.php
+++ b/classes/app/product.php
@@ -87,12 +87,12 @@ class Product {
     
     function getDescription($language = null) {
         $language = ($language === null) ? XHS_LANGUAGE : $language;
-        return isset($this->descriptions[$language]) ? stripslashes($this->descriptions[$language]) : '' ;
+        return isset($this->descriptions[$language]) ? $this->descriptions[$language] : '' ;
     }
      function getTeaser($language = null) {
         $language = ($language === null) ? XHS_LANGUAGE : $language;
        
-        return isset($this->teasers[$language]) ? stripslashes($this->teasers[$language]) : '' ;
+        return isset($this->teasers[$language]) ? $this->teasers[$language] : '' ;
     }
 
     function getPageLink($language, $label = null){

--- a/classes/app/xhs_backend_controller.php
+++ b/classes/app/xhs_backend_controller.php
@@ -281,12 +281,12 @@ class XHS_Backend_Controller extends XHS_Controller {
     }
 
     function contactSettings(){
-        $params['email']        = stripslashes($this->settings['order_email']);
-        $params['company_name'] = stripslashes($this->settings['company_name']);
-        $params['name']         = stripslashes($this->settings['name']);
-        $params['street']       = stripslashes($this->settings['street']);
-        $params['zip_code']     = stripslashes($this->settings['zip_code']);
-        $params['city']         = stripslashes($this->settings['city']);
+        $params['email']        = $this->settings['order_email'];
+        $params['company_name'] = $this->settings['company_name'];
+        $params['name']         = $this->settings['name'];
+        $params['street']       = $this->settings['street'];
+        $params['zip_code']     = $this->settings['zip_code'];
+        $params['city']         = $this->settings['city'];
 
         return $this->render('contactSettings', $params);
     }
@@ -363,7 +363,7 @@ class XHS_Backend_Controller extends XHS_Controller {
             else {
                 $row = '';
                 foreach($value as $k => $t){
-                    $row .= '$zShopSettings' . "['" . $key. "']" . "['$k'] = '" . addslashes($t) . "';\n";
+                    $row .= '$zShopSettings' . "['" . $key. "']" . "['$k'] = '" . addcslashes($t, '\'\\') . "';\n";
                 }
             }
             $save .= $row;
@@ -425,10 +425,8 @@ class XHS_Backend_Controller extends XHS_Controller {
         if(isset($_POST['xhsPrice'])){
             $product->setPrice($this->tidyPostString($_POST['xhsPrice']));
         }
-      //  var_dump($_POST['xhsTeaser']);
         if(isset($_POST['xhsTeaser'])){
-         //   $product->setTeaser($this->tidyPostString($_POST['xhsTeaser'], false));
-         $product->setTeaser(addslashes(stripslashes($_POST['xhsTeaser'])));
+         $product->setTeaser($this->tidyPostString($_POST['xhsTeaser'], false));
         }
         if(isset($_POST['xhsDescription'])){
             $product->setDescription($this->tidyPostString($_POST['xhsDescription'], false));

--- a/classes/app/xhs_controller.php
+++ b/classes/app/xhs_controller.php
@@ -186,13 +186,13 @@ class XHS_Controller {
         }
 
         $params['products'] = $this->products($category, $collectAll);
-        $params['selectedCategory'] = stripslashes($category);
+        $params['selectedCategory'] = $category;
         $params['categoryOptions'] = $this->categoryOptions();
         switch ($category) {
             case 'left_overs':
                 $params['categoryHeader'] = $this->catalog->category_for_the_left_overs[XHS_LANGUAGE];
                 break;
-            default:  $params['categoryHeader'] = stripslashes($category);
+            default:  $params['categoryHeader'] = $category;
                 break;
         }
         return $params;
@@ -243,11 +243,7 @@ class XHS_Controller {
         if($writeEntities === true){
             $string = htmlspecialchars($string);
         }
-        if(get_magic_quotes_gpc() === 1){
-            $string  = stripslashes($string);
-        }
-        return rtrim(addslashes($string));
-       // return addslashes($string);
+        return rtrim($string);
     }
 
     function addPaymentModule($module){

--- a/classes/paymentmodules/paypal/paypal.php
+++ b/classes/paymentmodules/paypal/paypal.php
@@ -168,10 +168,6 @@ class XHS_Paypal extends XHS_Payment_Module {
         if (isset($_POST['ppBusiness']))
         {
             $business = trim($_POST['ppBusiness']);
-            if (get_magic_quotes_gpc() === 1)
-            {
-                $business = stripslashes($business);
-            }
             $this->settings['business'] = '' . $business . '';
         }
         $file     = XHS_BASE_PATH . 'classes/paymentmodules/' . $this->name . '/settings.php';
@@ -202,7 +198,7 @@ class XHS_Paypal extends XHS_Payment_Module {
 
         foreach ($_POST as $key => $value)
         {
-            $value = urlencode(stripslashes($value));
+            $value = urlencode($value);
             $req .= "&$key=$value";
         }
 


### PR DESCRIPTION
The problem is that the we call `stripslashes()` and `addslashes()`
somewhat arbitrarily. Assuming that we require PHP ≥ 5.4.0 (or at least
that all `magic_quotes_*` settings are off) we actually don't need
stripslashes()` and `addslashes()` at all; instead, in some cases we
use `addcslashes()` where necessary. We keep a single occurrence of
`addslashes()`, though, namely where we print the product name as
argument to a JS function call in an inline event handler attribute. We
should really not do this at all, and it's probably best not to use any
inline event handlers altogether, but we can fix that later.