### PR TITLE
Close #19: Don't remove line breaks from annotation

### DIFF
--- a/classes/app/xhs_frontend_controller.php
+++ b/classes/app/xhs_frontend_controller.php
@@ -313,6 +313,9 @@ class XHS_Frontend_Controller extends XHS_Controller {
         {
             $params[$field]       = $value;
         }
+        if (isset($params['annotation'])) {
+            $params['annotation'] = nl2br($params['annotation']);
+        }
         $params['fee']        = $this->calculatePaymentFee();
         $params['cartItems']  = $this->collectCartItems();
         $params['cartSum']    = $_SESSION['xhsOrder']->getCartSum();
@@ -375,6 +378,9 @@ class XHS_Frontend_Controller extends XHS_Controller {
         foreach ($_SESSION['xhsCustomer'] as $field => $value)
         {
             $params[$field]       = isset($value) ? $value : '';
+        }
+        if (isset($params['annotation'])) {
+            $params['annotation'] = nl2br($params['annotation']);
         }
         $_SESSION['xhsOrder']->setFee($fee);
         $params['payment']    = $paymentModule;


### PR DESCRIPTION
If users enter line breaks in the annotation textarea, these should be
retained for the HTML confirmation (mail), so we simply apply
`nl2br()`.