### PR TITLE
Close #1: Localize decimal separator

### DIFF
--- a/classes/app/xhs_view.php
+++ b/classes/app/xhs_view.php
@@ -222,15 +222,10 @@ class XHS_View{
     }
 
     function formatFloat($sum){
-        if(XHS_LANGUAGE == 'en'){
-            $dec_sep = '.';
-            $thousands_sep = ',';
-        }else {
-// test            $dec_sep = ',';
-// test            $thousands_sep = '.';
-            $dec_sep = '.';
-            $thousands_sep = ',';
-        }
+        global $plugin_tx;
+
+        $dec_sep = trim($plugin_tx['xhshop']['config_decimal_separator']);
+        $thousands_sep = trim($plugin_tx['xhshop']['config_thousands_separator']);
         return number_format($sum, 2, $dec_sep, $thousands_sep);
     }
 

--- a/languages/de.php
+++ b/languages/de.php
@@ -1,5 +1,7 @@
 <?php
 $plugin_tx['xhshop']['config_cos_page']="?Shop/AGB";
+$plugin_tx['xhshop']['config_decimal_separator']=",";
+$plugin_tx['xhshop']['config_thousands_separator']=".";
 ###### errors ########
 $plugin_tx['xhshop']['hints_sorry_errors'] = 'Pardon! Noch ist der xhshop-Shop nicht betriebsbereit.';
 $plugin_tx['xhshop']['labels_needs_write_permission'] = 'Braucht Schreibrechte (0666)';

--- a/languages/en.php
+++ b/languages/en.php
@@ -1,5 +1,7 @@
 <?php
 $plugin_tx['xhshop']['config_cos_page']="?Shop/C.O.S.";
+$plugin_tx['xhshop']['config_decimal_separator']=".";
+$plugin_tx['xhshop']['config_thousands_separator']=",";
 ###### errors ########
 $plugin_tx['xhshop']['hints_sorry_errors'] = 'Sorry! There are some issuses that have to be fixed, before the xhshopShop is ready to use.';
 $plugin_tx['xhshop']['labels_needs_write_permission'] = 'needs write permission';


### PR DESCRIPTION
We refrain from introducing `NumberFormatter` because apparently
ext/intl isn't available on many shared hosting services. Instead we
stick with `number_format()` and add the language settings
`config_decimal_separator` and `config_thousands_separator` what
appears to be sufficient for our purposes. For regions where it is
uncommon to group thousands, `config_thousands_separator` can be simply
left blank.