### PR TITLE
Close #45: Replace oddOrEven() with CSS

### DIFF
--- a/classes/app/xhs_view.php
+++ b/classes/app/xhs_view.php
@@ -218,14 +218,6 @@ class XHS_View{
         return $this->formatFloat($sum)  . ' ' . $this->currency;
     }
 
-    function oddOrEven($index){
-        if ($index % 2 != 0) {
-            echo 'odd';
-            return;
-        }
-        echo 'even';
-    }
-
     function hint($key){
         if(isset($this->hints[$key])){
             echo($this->hints[$key]);

--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -36,11 +36,11 @@
 .xhsMain input[type="checkbox"], section.xhsScreen input[type="radio"] {
 	padding: 0 !important;
 }
-tr.even {
+#xhsProductsTable tr:nth-child(odd) {
 	background-color: #dfdfdf;
 	color: #333;
 }
-tr.odd {
+#xhsProductsTable tr:nth-child(even) {
 	background-color: #efefef;
 	color: #333;
 }

--- a/templates/backend/catalog.tpl
+++ b/templates/backend/catalog.tpl
@@ -18,7 +18,7 @@
 		foreach($this->products as $index=>$product){
 			$previous = $i > 0 ? $this->indices[$i - 1] : null;
 			$next = $i < count($this->products) - 1 ? $this->indices[$i + 1] : null; ?>
-			<tr class="<?php echo $this->oddOrEven($i); ?>">
+			<tr>
 				<td class="">
 				<?php if(isset($previous)){?>
 					<form action="" method="post">


### PR DESCRIPTION
We remove this method of `XHS_View`, and use respective :nth-child()
pseudo-selectors instead. Note, that we have to replace the odd and
even rules, because formerly the first row had class `even`.