### PR TITLE
Fix some HTML errors

### DIFF
--- a/classes/app/product.php
+++ b/classes/app/product.php
@@ -79,7 +79,7 @@ class Product {
      function getImage(){
          if((isset($this->image)) && strlen($this->image) > 0 && ($this->image <> '')) {
 
-            $image = '<a href="' . XHS_IMAGE_PATH.$this->image . '" alt="' .$this->getName(XHS_LANGUAGE) . '"  title="'.$this->getName(XHS_LANGUAGE). '" class="zoom"><img src="' . XHS_IMAGE_PATH.$this->image . '" alt="' .$this->getName(XHS_LANGUAGE) . '"  title="'.$this->getName(XHS_LANGUAGE). '"></a>';
+            $image = '<a href="' . XHS_IMAGE_PATH.$this->image . '" title="'.$this->getName(XHS_LANGUAGE). '" class="zoom"><img src="' . XHS_IMAGE_PATH.$this->image . '" alt="' .$this->getName(XHS_LANGUAGE) . '"  title="'.$this->getName(XHS_LANGUAGE). '"></a>';
             return $image;
         }
         return '';
@@ -125,7 +125,7 @@ class Product {
     function getPreviewPicture(){
         if((isset($this->previewPicture)) && ($this->previewPicture <> '')) {
             
-            $image = '<a href="' . XHS_IMAGE_PATH.$this->image . '" alt="' . $this->getName(XHS_LANGUAGE) . ' - Preview"  title="' . $this->getName(XHS_LANGUAGE) . '" class="zoom"><img src="'. XHS_PREVIEW_PIC_PATH . $this->previewPicture. '" alt="' .$this->getName(XHS_LANGUAGE) .' - Preview"  title="'.$this->getName(XHS_LANGUAGE). '"></a>';
+            $image = '<a href="' . XHS_IMAGE_PATH.$this->image . '" title="' . $this->getName(XHS_LANGUAGE) . '" class="zoom"><img src="'. XHS_PREVIEW_PIC_PATH . $this->previewPicture. '" alt="' .$this->getName(XHS_LANGUAGE) .' - Preview"  title="'.$this->getName(XHS_LANGUAGE). '"></a>';
             return $image;
         }
         return '';

--- a/classes/app/xhs_view.php
+++ b/classes/app/xhs_view.php
@@ -254,7 +254,7 @@ class XHS_View{
         $html =    "\n\t" . '<select title="' . $this->labels['cat_select'] . '" name="xhsCategory" onchange="this.parentNode.submit();">';
         foreach($this->categoryOptions as $category){
             $selected = (html_entity_decode($category['value']) == html_entity_decode($this->selectedCategory)) ? ' selected="selected"' : '';
-            $html .= "\n\t\t" . '<option value="' . $category['value'] . '"' . $selected . '">' . $category['label'] . '</option>';
+            $html .= "\n\t\t" . '<option value="' . $category['value'] . '"' . $selected . '>' . $category['label'] . '</option>';
         }
 
         $html .= "\n\t" .'</select>';


### PR DESCRIPTION
We remove the alt texts from the anchors, where they don't make sense,
and also remove a superfluous quotation mark from the options.