### PR TITLE
Improve ordering of products

### DIFF
--- a/classes/app/xhs_backend_controller.php
+++ b/classes/app/xhs_backend_controller.php
@@ -31,6 +31,9 @@ class XHS_Backend_Controller extends XHS_Controller {
             $swap = $this->catalog->getProduct($_POST['xhsProductSwapID']);
             $this->catalog->swapSortIndex($myself, $swap);
         }
+		if (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest') {
+			exit;
+		}
 
         $indices    = array();
         $hints      = array();

--- a/js/xhsbackend.js
+++ b/js/xhsbackend.js
@@ -43,3 +43,83 @@ function xhsAssureDelete(string) {
 function test(test) {
 	alert(test);
 }
+
+if ("visibilityState" in document) {
+	document.addEventListener("DOMContentLoaded", function () {
+		var each = Array.prototype.forEach;
+	
+		function rowOfForm(form) {
+			var element = form.parentNode;
+	
+			while (element.tagName !== "TR") {
+				element = element.parentNode;
+			}
+			return element;
+		}
+	
+		function serialize(form) {
+			var params = [];
+			each.call(form.elements, function (element) {
+				if (!element.name) {
+					return;
+				}
+				params.push(element.name + "=" + encodeURIComponent(element.value));
+			});
+			return params.join("&");
+		}
+	
+		function submit(form) {
+			var request = new XMLHttpRequest;
+			request.open("POST", form.action, true);
+			request.setRequestHeader("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
+			request.setRequestHeader("X-Requested-With", "XMLHttpRequest");
+			request.send(serialize(form));
+		}
+	
+		function fixSwapIds() {
+			var forms = document.getElementsByClassName("xhsMoveUp");
+			var form;
+			if ((form = forms[0])) {
+				form.xhsProductSwapID.value = "";
+				form.style.display = "none";
+			}
+			for (var i = 1; i < forms.length; i++) {
+				form = forms[i];
+				form.xhsProductSwapID.value = forms[i-1].xhsProductID.value;
+				form.style.display = "";
+			}
+			var forms = document.getElementsByClassName("xhsMoveDown");
+			for (var i = 0; i < forms.length - 1; i++) {
+				form = forms[i];
+				form.xhsProductSwapID.value = forms[i+1].xhsProductID.value;
+				form.style.display = "";
+			}
+			if ((form = forms[forms.length-1])) {
+				form.xhsProductSwapID.value = "";
+				form.style.display = "none";
+			}
+		}
+	
+		each.call(document.getElementsByClassName("xhsMoveUp"), function (form) {
+			form.addEventListener("submit", function (event) {
+				var thisRow = rowOfForm(this);
+				submit(this);
+				var thatRow = thisRow.previousElementSibling;
+				thisRow.parentNode.insertBefore(thisRow, thatRow);
+				fixSwapIds();
+				event.preventDefault();
+			});
+		});
+	
+		each.call(document.getElementsByClassName("xhsMoveDown"), function (form) {
+			form.addEventListener("submit", function (event) {
+				var thisRow = rowOfForm(this);
+				submit(this);
+				var thatRow = thisRow.nextElementSibling;
+				thisRow.parentNode.insertBefore(thatRow, thisRow);
+				fixSwapIds();
+				event.preventDefault();
+			});
+		});
+	});
+}

--- a/templates/backend/catalog.tpl
+++ b/templates/backend/catalog.tpl
@@ -20,8 +20,7 @@
 			$next = $i < count($this->products) - 1 ? $this->indices[$i + 1] : null; ?>
 			<tr>
 				<td class="">
-				<?php if(isset($previous)){?>
-					<form action="" method="post">
+					<form action="" method="post" class="xhsMoveUp" <?php if (!isset($previous)) echo 'style="display: none"'?>>
 						<input type="hidden" name="xhsProductID" value="<?php echo $index; ?>">
 						<input type="hidden" name="xhsProductSwapID" value="<?php echo $previous; ?>">
 						<input type="hidden" name="xhsTask" value="productList">
@@ -29,12 +28,7 @@
 						<input type="hidden" name="xhsCategory" value="<?php echo $this->category; ?>">
 						<button class="xhsProdUp" title="swap sort index with previous product"><span class="fa fa-chevron-up"></span></button>
 					</form>
-				<?php }
-				else { ?>
-						<!--<button class="xhsProdUp"><span class="fa"> </span></button>-->
-				<?php } ?>
-				<?php if(isset($next)){?>
-					<form action="" method="post" class="xhsInl">
+					<form action="" method="post" class="xhsInl xhsMoveDown" <?php if (!isset($next)) echo 'style="display: none"'?>>
 						<input type="hidden" name="xhsProductID" value="<?php echo $index; ?>">
 						<input type="hidden" name="xhsProductSwapID" value="<?php echo $next; ?>">
 						<input type="hidden" name="xhsTask" value="productList">
@@ -42,7 +36,6 @@
 						<input type="hidden" name="xhsCategory" value="<?php echo $this->category; ?>">
 						<button class="xhsProdDown" title="swap sort index with previous product"><span class="fa fa-chevron-down"></span></button>
 					</form>
-				<?php } ?>
 				</td>
 				<td class="xhsTdTop"><strong><?php echo strip_tags($product['name']); ?></strong>
 					<p class=""><?php echo $this->labels['price'];?> <?php echo $this->formatCurrency($product['price']); ?><br>


### PR DESCRIPTION
Changing the order of products in the back-end is horrible. To really
fix this, we would need to completely rework the products table, so
that it is a single form. Since that appears too much a change for
version 1, we deploy a workaround, namely that the swap requests are
now sent via XHR (aka. Ajax), if the browser is modern, which is faster
and avoids scrolling to the top after each swap operation.