### PR TITLE
Close #141: Add RDFa markup for Products and Offers

### DIFF
--- a/classes/FrontEndController.php
+++ b/classes/FrontEndController.php
@@ -665,6 +665,7 @@ class FrontEndController extends Controller
         if (!$product) {
             return $this->productList();
         }
+        $previewPicturePath = $product->getPreviewPicturePath();
         $params = array();
         $params['name']        = $product->getName();
         $params['teaser']      = $product->getTeaser();
@@ -672,16 +673,18 @@ class FrontEndController extends Controller
         $params['button']      = $this->addToCartButton($product);
         $params['variants']    = count($product->getVariants() > 0) ? $product->getVariants() : false;
         $params['price']       = $product->getGross();
+        $params['currency']    = $this->settings['currency_code'];
         $params['uid']         = $product->getUid();
         $params['hideVat']     = (bool) $this->settings['dont_deal_with_taxes'];
         $params['vatRate']     = $this->settings['vat_' . $product->getVat()];
         $params['vatInfo']     = $this->vatInfo();
         $params['image']       = $this->viewProvider->linkedImage(
-            $product->getPreviewPicturePath(),
+            $previewPicturePath,
             $product->getImagePath(),
             $product->getName(XHS_LANGUAGE),
             'zoom_g'
         );
+        $params['previewPicture'] = preg_replace('/\/\.\/|\/.{2}\/\.\.\//', '/', CMSIMPLE_URL . $previewPicturePath);
         $params['shippingCostsUrl'] = $this->settings['shipping_costs_page'];
         $this->bridge->setTitle($params['name']);
         $this->bridge->setMeta('description', $params['teaser']);

--- a/templates/frontend/productDetails.tpl
+++ b/templates/frontend/productDetails.tpl
@@ -1,10 +1,11 @@
 <?php ?>
 <a class="xhsShopButton" href="?<?php echo XHS_URL;?>"><span class="fa fa-list fa-lg fa-fw"></span> <?php echo $this->labels['products_list']; ?></a>
-<article class="xhsMain xhsPrdDetails">
-	<h1 class="xhsProdTitle">%NAME%</h1>
+<article class="xhsMain xhsPrdDetails" vocab="http://schema.org/" typeof="Product">
+	<h1 class="xhsProdTitle" property="name">%NAME%</h1>
 	<div class="xhsPrdDetTeaser">%TEASER%</div>
 	<div class="xhsPrevPic">%IMAGE%</div>
-	<div class="xhsProdDescript">%DESCRIPTION%</div>
+	<meta property="image" content="%PREVIEWPICTURE%">
+	<div class="xhsProdDescript" property="description">%DESCRIPTION%</div>
 	<div class="xhsInfoBlock">
 		<form method="post">
 			%CSRF_TOKEN_INPUT%
@@ -19,7 +20,11 @@
 				</select>
 			</div>
 			<?php } ?>
-			<div class="xhsPrdPrice"><span class="xhsPrdPriceLabel"><?php echo $this->labels['price']; ?><br>
+			<div class="xhsPrdPrice" property="offers" typeof="Offer">
+				<meta property="price" content="<?php echo $this->price; ?>">
+				<meta property="priceCurrency" content="<?php echo $this->currency; ?>">
+				<meta property="availability" content="http://schema.org/InStock">
+				<span class="xhsPrdPriceLabel"><?php echo $this->labels['price']; ?><br>
 				<?php $this->hint($this->vatInfo); ?> <?php if (!$this->hideVat) echo $this->formatPercentage($this->vatRate) ; ?><br><?php echo $this->shippingCostsHint(); ?></span> <span class="xhsPrdPriceNum"><?php echo $this->formatCurrency($this->price); ?></span></div>
 			<input class="xhsInpAmount" type="number" min="1" step="1" name="xhsAmount" value="1">
 			x


### PR DESCRIPTION
On the automatically generated product detail pages, we add schema.org
conforming RDFa markup for `Product`s and `Offer`s, supporting all
required properties and those recommended properties for which we
already have data available.