### PR TITLE
Fix #20: Paypal problems

### DIFF
--- a/classes/FrontEndController.php
+++ b/classes/FrontEndController.php
@@ -732,13 +732,9 @@ class FrontEndController extends Controller
 
     public function handleRequest($request = null)
     {
-        if (isset($_POST['ipn_track_id'])) {
+        if (isset($_GET['xhsIpn'])) {
             $this->loadPaymentModule('paypal');
             $this->paymentModules['paypal']->ipn();
-        }
-        if (file_exists(XHS_CONTENT_PATH . 'xhshop/tmp_orders/pp_' . session_id() . '.sent')) {
-            unlink(XHS_CONTENT_PATH . 'xhshop/tmp_orders/pp_' . session_id() . '.sent');
-            return $this->thankYou();
         }
         if (!$this->settings['published']) {
             return $this->closed();

--- a/classes/FrontEndController.php
+++ b/classes/FrontEndController.php
@@ -464,21 +464,29 @@ class FrontEndController extends Controller
      *
      * @return <string>
      */
-    public function finishCheckOut()
+    public function finishCheckOut($viaIpn = false)
     {
         if (!$this->canOrder()) {
+            if ($viaIpn) {
+                return;
+            }
             $this->relocateToCheckout('cart', 302);
         } elseif (!$this->isValidCustomer()) {
+            if ($viaIpn) {
+                return;
+            }
             $this->relocateToCheckout('customersData', 302);
         }
-        $this->csrfProtector->check();
-        if (!isset($_SESSION['xhsCustomer']) || !isset($_SESSION['xhsOrder'])) {
-            return '';
+        if (!$viaIpn) {
+            $this->csrfProtector->check();
         }
         $bill = $this->writeBill();
 
         $sent = $this->sendEmails($bill);
 
+        if ($viaIpn) {
+            return;
+        }
         if ($sent === true) {
             $this->relocateToCheckout('thankYou', 303);
         } else {

--- a/classes/FrontEndController.php
+++ b/classes/FrontEndController.php
@@ -464,7 +464,7 @@ class FrontEndController extends Controller
      *
      * @return <string>
      */
-    private function finishCheckOut()
+    public function finishCheckOut()
     {
         if (!$this->canOrder()) {
             $this->relocateToCheckout('cart', 302);

--- a/classes/payment/Paypal.php
+++ b/classes/payment/Paypal.php
@@ -99,7 +99,7 @@ class Paypal extends PaymentModule
 
 // post back to PayPal system to validate
 
-        $header = "POST /cgi-bin/webscr HTTP/1.0\r\n";
+        $header = "POST /cgi-bin/webscr HTTP/1.1\r\n";
 
         if ($this->settings['sandbox']) {
             $header .= "Host: ipnpb.sandbox.paypal.com:443\r\n";
@@ -107,8 +107,10 @@ class Paypal extends PaymentModule
             $header .= "Host: ipnpb.paypal.com:443\r\n";
         }
         $header .= "Content-Type: application/x-www-form-urlencoded\r\n";
-        $header .= "Content-Length: " . strlen($req) . "\r\n\r\n";
-        $header .= "User-Agent: XH-Shop-IPN-VerificationScript\r\n\r\n";
+        $header .= "Content-Length: " . strlen($req) . "\r\n";
+        $header .= "User-Agent: XH-Shop-IPN-VerificationScript\r\n";
+        $header .= "Connection: close\r\n";
+        $header .= "\r\n";
 
         if ($this->settings['sandbox']) {
             $fp = fsockopen('ssl://ipnpb.sandbox.paypal.com', 443, $errno, $errstr, 30);

--- a/classes/payment/Paypal.php
+++ b/classes/payment/Paypal.php
@@ -109,6 +109,7 @@ class Paypal extends PaymentModule
         }
         $header .= "Content-Type: application/x-www-form-urlencoded\r\n";
         $header .= "Content-Length: " . strlen($req) . "\r\n\r\n";
+        $header .= "User-Agent: XH-Shop-IPN-VerificationScript\r\n\r\n";
 
         if ($this->settings['sandbox']) {
             $fp = fsockopen('ssl://ipnpb.sandbox.paypal.com', 443, $errno, $errstr, 30);

--- a/classes/payment/Paypal.php
+++ b/classes/payment/Paypal.php
@@ -126,17 +126,17 @@ class Paypal extends PaymentModule
         if (fwrite($fp, $payload) !== strlen($payload)) {
             $this->handshakeFailed();
         }
-        while (!feof($fp)) {
-            $res = fgets($fp);
-            if ($res === 'VERIFIED') {
+        $res = stream_get_contents($fp);
+        list($headers, $body) = explode("\r\n\r\n", $res);
+        switch (trim($body)) {
+            case 'VERIFIED':
                 $this->handleVerifiedIpn();
                 break;
-            } elseif ($res === 'INVALID') {
+            case 'INVALID':
                 // just ignore this IPN
                 break;
-            } else {
+            default:
                 $this->handshakeFailed();
-            }
         }
         fclose($fp);
         while (ob_get_level()) {

--- a/classes/payment/Paypal.php
+++ b/classes/payment/Paypal.php
@@ -159,8 +159,8 @@ class Paypal extends PaymentModule
         global $xhsController;
 
         $file = XHS_CONTENT_PATH . 'xhshop/tmp_orders/pp_' . $_POST['custom'];
-        if ($_POST['receiver_email '] === $this->settings['email']
-                && $_POST['payment_status '] === 'Completed'
+        if ($_POST['receiver_email'] === $this->settings['email']
+                && $_POST['payment_status'] === 'Completed'
                 && file_exists($file . '.temp')) {
             $temp                    = implode("", file($file . '.temp'));
             $temp                    = unserialize($temp);

--- a/classes/payment/Paypal.php
+++ b/classes/payment/Paypal.php
@@ -158,12 +158,10 @@ class Paypal extends PaymentModule
     {
         global $xhsController;
 
-        /*
-         *  bei Bedarf pruefen, ob die Bestellung ausgefuehrt werden soll. (Stimmt die Haendler-E-Mail, ...?
-         */
-      
         $file = XHS_CONTENT_PATH . 'xhshop/tmp_orders/pp_' . $_POST['custom'];
-        if (file_exists($file . '.temp')) {
+        if ($_POST['receiver_email '] === $this->settings['email']
+                && $_POST['payment_status '] === 'Completed'
+                && file_exists($file . '.temp')) {
             $temp                    = implode("", file($file . '.temp'));
             $temp                    = unserialize($temp);
             $_SESSION['xhsCustomer'] = $temp['xhsCustomer'];

--- a/classes/payment/Paypal.php
+++ b/classes/payment/Paypal.php
@@ -103,17 +103,17 @@ class Paypal extends PaymentModule
         $header = "POST /cgi-bin/webscr HTTP/1.0\r\n";
 
         if ($this->settings['sandbox']) {
-            $header .= "Host: www.sandbox.paypal.com:443\r\n";
+            $header .= "Host: ipnpb.sandbox.paypal.com:443\r\n";
         } else {
-            $header .= "Host: www.paypal.com:443\r\n";
+            $header .= "Host: ipnpb.paypal.com:443\r\n";
         }
         $header .= "Content-Type: application/x-www-form-urlencoded\r\n";
         $header .= "Content-Length: " . strlen($req) . "\r\n\r\n";
 
         if ($this->settings['sandbox']) {
-            $fp = fsockopen('ssl://www.sandbox.paypal.com', 443, $errno, $errstr, 30);
+            $fp = fsockopen('ssl://ipnpb.sandbox.paypal.com', 443, $errno, $errstr, 30);
         } else {
-            $fp = fsockopen('ssl://www.paypal.com', 443, $errno, $errstr, 30);
+            $fp = fsockopen('ssl://ipnpb.paypal.com', 443, $errno, $errstr, 30);
         }
 
         if (!$fp) {

--- a/classes/payment/Paypal.php
+++ b/classes/payment/Paypal.php
@@ -133,11 +133,6 @@ class Paypal extends PaymentModule
               
                 $file = XHS_CONTENT_PATH . 'xhshop/tmp_orders/pp_' . $_POST['custom'];
                 if (file_exists($file . '.temp')) {
-                    if (!(bool) session_id()) {
-                        session_id($_POST['custom']);
-                        session_start();
-                    }
-
                     $temp                    = implode("", file($file . '.temp'));
                     $temp                    = unserialize($temp);
                     $_SESSION['xhsCustomer'] = $temp['xhsCustomer'];

--- a/classes/payment/Paypal.php
+++ b/classes/payment/Paypal.php
@@ -162,12 +162,15 @@ class Paypal extends PaymentModule
         if ($_POST['receiver_email'] === $this->settings['email']
                 && $_POST['payment_status'] === 'Completed'
                 && file_exists($file . '.temp')) {
+            XH_logMessage('info', 'xhshop', 'ipn', 'processed: ' . serialize($_POST));
             $temp                    = implode("", file($file . '.temp'));
             $temp                    = unserialize($temp);
             $_SESSION['xhsCustomer'] = $temp['xhsCustomer'];
             $_SESSION['xhsOrder']    = $temp['xhsOrder'];
             unlink($file . '.temp');
             $xhsController->finishCheckout();
+        } else {
+            XH_logMessage('info', 'xhshop', 'ipn', 'ignored: ' . serialize($_POST));
         }
     }
 }

--- a/classes/payment/Paypal.php
+++ b/classes/payment/Paypal.php
@@ -128,15 +128,13 @@ class Paypal extends PaymentModule
         }
         $res = stream_get_contents($fp);
         list($headers, $body) = explode("\r\n\r\n", $res);
-        switch (trim($body)) {
-            case 'VERIFIED':
-                $this->handleVerifiedIpn();
-                break;
-            case 'INVALID':
+        $lines = explode("\r\n", $body);
+        if (in_array('VERIFIED', $lines)) {
+            $this->handleVerifiedIpn();
+        } elseif (in_array('INVALID', $lines)) {
                 // just ignore this IPN
-                break;
-            default:
-                $this->handshakeFailed(sprintf('unexpected response for IPN pingback request: %s', trim($body)));
+        } else {
+            $this->handshakeFailed(sprintf('unexpected response for IPN pingback request: %s', trim($body)));
         }
         fclose($fp);
         while (ob_get_level()) {

--- a/classes/payment/Paypal.php
+++ b/classes/payment/Paypal.php
@@ -168,7 +168,7 @@ class Paypal extends PaymentModule
             $_SESSION['xhsCustomer'] = $temp['xhsCustomer'];
             $_SESSION['xhsOrder']    = $temp['xhsOrder'];
             unlink($file);
-            $xhsController->finishCheckout();
+            $xhsController->finishCheckout(true);
         } else {
             XH_logMessage('info', 'xhshop', 'ipn', 'ignored: ' . serialize($_POST));
         }

--- a/classes/payment/Paypal.php
+++ b/classes/payment/Paypal.php
@@ -158,16 +158,16 @@ class Paypal extends PaymentModule
     {
         global $xhsController;
 
-        $file = XHS_CONTENT_PATH . 'xhshop/tmp_orders/pp_' . $_POST['custom'];
+        $file = XHS_CONTENT_PATH . 'xhshop/tmp_orders/pp_' . $_POST['custom'] . '.temp';
         if ($_POST['receiver_email'] === $this->settings['email']
                 && $_POST['payment_status'] === 'Completed'
-                && file_exists($file . '.temp')) {
+                && file_exists($file)) {
             XH_logMessage('info', 'xhshop', 'ipn', 'processed: ' . serialize($_POST));
-            $temp                    = implode("", file($file . '.temp'));
+            $temp                    = file_get_contents($file);
             $temp                    = unserialize($temp);
             $_SESSION['xhsCustomer'] = $temp['xhsCustomer'];
             $_SESSION['xhsOrder']    = $temp['xhsOrder'];
-            unlink($file . '.temp');
+            unlink($file);
             $xhsController->finishCheckout();
         } else {
             XH_logMessage('info', 'xhshop', 'ipn', 'ignored: ' . serialize($_POST));


### PR DESCRIPTION
We overhaul the Paypal payment module. Some issues already have been in Wellrad 1.2.1 and even more serious issues have been introduced during our commits; all these are suppossed to be fixed now.

Furthermore we're adding considerable logging regarding the IPN handling, which may be helpful for tracking down problems and bugs. We do not internationalize these log messages, because it's not even clear whether we should keep them for GA.

We also change the handling of purging the cart and showing the Thank-You page. This is now done, when the buyers return from Paypal after having made the payment. If they don't return, the cart won't be purged, but that still appears to be better than thanking them for the order when they visit the shop hours or even days after ordering.