### PR TITLE
Close #150: Replace `<input type=number>` with `<input type=text>`

### DIFF
--- a/classes/BackEndController.php
+++ b/classes/BackEndController.php
@@ -223,6 +223,7 @@ class BackEndController extends Controller
     private function saveProduct()
     {
         $this->csrfProtector->check();
+        $html = '';
         $id = isset($_POST['xhsProductID']) ? $_POST['xhsProductID'] : 'new';
         if (key_exists($id, $this->catalog->getProducts())) {
             $product = $this->catalog->getProduct($id);
@@ -233,10 +234,29 @@ class BackEndController extends Controller
             $product->setName($this->tidyPostString($_POST['xhsName']));
         }
         if (isset($_POST['xhsWeight'])) {
-            $product->setWeight(new Decimal($this->tidyPostString($_POST['xhsWeight'])));
+            if (is_numeric(ltrim($_POST['xhsWeight']))) {
+                $product->setWeight(new Decimal($this->tidyPostString($_POST['xhsWeight'])));
+            } else {
+                $html .= XH_message(
+                    'fail',
+                    $this->viewProvider->hints['wrong_format'],
+                    sprintf($this->viewProvider->labels['shipping_unit'], $this->settings['shipping_unit'])
+                );
+                $product->setWeight(Decimal::zero());
+            }
         }
         if (isset($_POST['xhsPrice'])) {
-            $product->setPrice(new Decimal($this->tidyPostString($_POST['xhsPrice'])));
+            if (is_numeric(ltrim($_POST['xhsPrice']))) {
+                $product->setPrice(new Decimal($this->tidyPostString($_POST['xhsPrice'])));
+            } else {
+                $html .= XH_message(
+                    'fail',
+                    $this->viewProvider->hints['wrong_format'],
+                    $this->viewProvider->labels['price']
+                    
+                );
+                $product->setPrice(Decimal::zero());
+            }
         }
         if (isset($_POST['xhsTeaser'])) {
             $product->setTeaser($this->tidyPostString($_POST['xhsTeaser'], false));
@@ -303,7 +323,7 @@ class BackEndController extends Controller
             $this->catalog->updateProduct($id, $product);
         }
 
-        return $this->editProduct($id);
+        return $html . $this->editProduct($id);
     }
 
     /**

--- a/classes/View.php
+++ b/classes/View.php
@@ -8,7 +8,7 @@ abstract class View
     protected $themePath = null;
     private $currency;
     private $params = array();
-    protected $hints = array();
+    public $hints = array();
     public $labels = array();
     protected $shippingCountries = array();
 

--- a/classes/View.php
+++ b/classes/View.php
@@ -129,8 +129,6 @@ abstract class View
             $params = array('style'=> 'text-align: right;', 'size'=>'5');
         }
 
-        $params['type'] = 'number';
-        $params['step'] = '0.01';
         if (!($value instanceof Decimal)) {
             $value = new Decimal($value);
         }

--- a/languages/de.php
+++ b/languages/de.php
@@ -99,6 +99,7 @@ $plugin_tx['xhshop']['labels_all_categories']='Alle Artikel';
 $plugin_tx['xhshop']['hints_edit_product']="Artikel bearbeiten";
 $plugin_tx['xhshop']['hints_delete_product']="Artikel löschen";
 $plugin_tx['xhshop']['hints_confirm_delete']="Soll \"%s\" wirklich gelöscht werden?";
+$plugin_tx['xhshop']['hints_wrong_format']="%s: falsches Dezimalzahlformat! (Verwenden Sie immer einen Dezimalpunkt!)";
 $plugin_tx['xhshop']['labels_product_name']='Bezeichnung';
 $plugin_tx['xhshop']['labels_product_variants']='verfügbare Varianten';
 $plugin_tx['xhshop']['hints_product_variants'] = '(Semikolon als Trenner. Beispiel: <i>"rot; grün; blau"</i>)';

--- a/languages/en.php
+++ b/languages/en.php
@@ -99,6 +99,7 @@ $plugin_tx['xhshop']['labels_all_categories']='show all';
 $plugin_tx['xhshop']['hints_edit_product']="Edit product";
 $plugin_tx['xhshop']['hints_delete_product']="Delete product";
 $plugin_tx['xhshop']['hints_confirm_delete']="Really delete \"%s\"?";
+$plugin_tx['xhshop']['hints_wrong_format']="%s: wrong decimal format! (Always use a decimal point!)";
 $plugin_tx['xhshop']['labels_product_name']='Name';
 $plugin_tx['xhshop']['labels_product_variants']='Variants';
 $plugin_tx['xhshop']['hints_product_variants'] = '(Use semicolon as separator, e. g.: <i>&laquo;red; green; blue&raquo;</i>)';


### PR DESCRIPTION
Although support for `<input type=number>` is generally good nowadays,
apparently proper support for decimal numbers is still weak, and
browsers are behaving rather differently, see
https://cmsimpleforum.com/viewtopic.php?f=16&t=12956&start=10#p61533.

To avoid confusion, and to make it possible to document what has to be
entered as price and "weight" in the product form, and also to be
consistent with decimal numbers in the configuration we switch back to
good old `<input type=text>` fields.