### PR TITLE
Fix #148: Invalidate carts if config is saved

### DIFF
--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -67,6 +67,11 @@ abstract class Controller
         $this->viewProvider = new $viewProvider();
         $this->viewProvider->setCurrency($this->settings['default_currency']);
         $this->viewProvider->setShippingCountries($this->settings['shipping_countries']);
+
+        if (isset($_SESSION['xhsToken']) && $_SESSION['xhsToken'] !== $this->settings['token']) {
+            unset($_SESSION['xhsOrder'], $_SESSION['xhsCustomer']);
+        }
+        $_SESSION['xhsToken'] = $this->settings['token'];
     }
 
     protected function getShippingCountries()

--- a/config/config.php
+++ b/config/config.php
@@ -1,6 +1,7 @@
 <?php
 
 $plugin_cf['xhshop']['shop_published']="@PUBLISHED@";
+$plugin_cf['xhshop']['shop_token']="";
 $plugin_cf['xhshop']['shop_minimum_order']="20.00";
 $plugin_cf['xhshop']['shop_default_currency']="€";
 $plugin_cf['xhshop']['shop_currency_code']="EUR";

--- a/config/metaconfig.php
+++ b/config/metaconfig.php
@@ -1,6 +1,7 @@
 <?php
 
 $plugin_mcf['xhshop']['shop_published']="bool";
+$plugin_mcf['xhshop']['shop_token']="random";
 $plugin_mcf['xhshop']['shop_bill_format']="enum:csv,rtf";
 $plugin_mcf['xhshop']['taxes_vat_default_full']="bool";
 $plugin_mcf['xhshop']['taxes_dont_deal_with_taxes']="bool";


### PR DESCRIPTION
To avoid issues with changes to the shop configuration during ordering,
we invalidate all shopping carts as soon as the configuration is saved,
what happens whenever the shop's publishing state changes.

The shop providers have to regard, that for any non trivial change to
the language specific configuration or to the products, the shop *has*
*to* be switched to maintenance mode. Trivial changes would be, for
instance, fixing a typo in a product description, or adding a new
product.