### PR TITLE
Add hi_fancybox to catalogue images

### DIFF
--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -180,6 +180,7 @@ abstract class Controller
             $products[$index]['detailLink'] = $detailLink;
             $products[$index]['price'] = $product->getGross();
             $products[$index]['sortIndex'] = $product->getSortIndex();
+            $products[$index]['isAvailable'] = $product->isAvailable();
             if ($detailLink!='' || !$product->getImageName()) {
                 $products[$index]['previewPicture'] = $this->viewProvider->linkedImage(
                     $product->getPreviewPicturePath(),

--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -180,13 +180,22 @@ abstract class Controller
             $products[$index]['detailLink'] = $detailLink;
             $products[$index]['price'] = $product->getGross();
             $products[$index]['sortIndex'] = $product->getSortIndex();
-            $products[$index]['isAvailable'] = $product->isAvailable();
-            $products[$index]['previewPicture'] = $this->viewProvider->linkedImage(
-                $product->getPreviewPicturePath(),
-                $this->bridge->translateUrl($product->getDetailsLink(XHS_LANGUAGE)),
-                $product->getName(),
-                ''
-            );
+            if ($detailLink!='' || !$product->getImageName()) {
+                $products[$index]['previewPicture'] = $this->viewProvider->linkedImage(
+                    $product->getPreviewPicturePath(),
+                    $this->bridge->translateUrl($product->getDetailsLink(XHS_LANGUAGE)),
+                    $product->getName(),
+                    ''
+                );
+            }
+            else {
+                $products[$index]['previewPicture'] = $this->viewProvider->linkedImage(
+                    $product->getPreviewPicturePath(),
+                    $product->getImagePath(),
+                    $product->getName(),
+                    'zoom'
+                );
+            }
             $products[$index]['categories'] = $product->getCategories();
             if ($product->hasVariants()) {
                 $products[$index]['variants'] = $product->getVariants();


### PR DESCRIPTION
..to products with product image and without details page.

hi_fancybox link im Katalog bei Artikeln mit Artikelbild aber ohne Details Seite.
Kommt etwas grauslig daher, weil View::image() nicht existiert und View::linkedImage erst innerhalt der Methode enscheidet für verlinktes Bild oder Einzelbild.