### PR TITLE
Fix #217: variant bug when page has several cartButtons

### DIFF
--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -112,6 +112,7 @@ abstract class Controller
         if (!($this->viewProvider instanceof View)) {
             return "XHSController:render no view provider!";
         }
+        $this->viewProvider->resetParams();
         if (isset($params)) {
             foreach ($params as $key => $value) {
                 $this->viewProvider->assignParam($key, $value);

--- a/classes/View.php
+++ b/classes/View.php
@@ -40,6 +40,12 @@ abstract class View
         $this->currency = $currency;
     }
 
+    public function resetParams()
+    {
+        $this->params = array();
+        unset($this->variants);
+    }
+
     public function assignParam($key, $param)
     {
         if (is_string($param)) {

--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -1,5 +1,5 @@
 /*** Cart-Box for CMSimple_XH-Sites ***/
-#cartButton {
+.cartButton {
 	border: 2px solid #f60;
 	clear: both;
 	margin: 2em 0;
@@ -75,7 +75,7 @@ input.linkButton:hover {
 	text-decoration: underline;
 	color: maroon;
 }
-#cartButton {
+.cartButton {
 	border: 2px solid #f60;
 	clear: both;
 	margin: 2em 0;

--- a/templates/frontend/addToCartButton.tpl
+++ b/templates/frontend/addToCartButton.tpl
@@ -1,5 +1,5 @@
 <?php ?>
-<section id="cartButton" class="xhsMain">
+<section class="cartButton xhsMain">
 	<h1 class="xhsInl xhsLft"><?php echo $this->productName; ?></h1>
 	<div class="xhsInfoBlock">
 		<div class="xhsPrdPrice"><span class="xhsPrdPriceLabel"><?php echo $this->labels['price'];?></span> <span class="xhsPrdPriceNum"><?php echo $this->formatCurrency($this->product->getGross()); ?></span></div>


### PR DESCRIPTION
We have to properly reset the view params, so that we do not
accidentially pick up params from an earlier rendering.  Unfortunately,
we are using some dynamic properties, what makes that slightly harder
and more brittle than necessary.

We also have to make sure that there is only ever a single element with
a certain ID.  Since there is no need to have an ID for the cart
buttons, we change that to a class.  This is a BC break, though, due to
customizations.