### PR TITLE
Fix #218: If Allow Show All is off, still the whole Shop is shown

### DIFF
--- a/classes/BackEndController.php
+++ b/classes/BackEndController.php
@@ -175,6 +175,7 @@ class BackEndController extends Controller
         $params['categories'] =  parent::categories();
         $params['leftOverCat'] = $this->catalog->getFallbackCategory();
         $params['xhsDefaultCat'] = $this->catalog->getDefaultCategory();
+        $params['allowShowAll'] = $this->settings['allow_show_all'];
         $params['csrf_token_input'] = $this->csrfProtector->tokenInput();
 
         return $this->render('categories', $params);

--- a/classes/Catalogue.php
+++ b/classes/Catalogue.php
@@ -10,11 +10,13 @@ class Catalogue
     private $category_for_the_left_overs;
     private $default_category;
     private $version;
+    private $allowShowAll;
 
-    public function __construct($separator, $version)
+    public function __construct($separator, $version, $allowShowAll)
     {
         $this->version = $version;
         $this->separator = $separator;
+        $this->allowShowAll = (bool) $allowShowAll;
         $this->products = array();
         $this->categories = array();
 
@@ -29,6 +31,13 @@ class Catalogue
 
         $this->categories = $categories;
         $this->category_for_the_left_overs = $category_for_the_left_overs;
+        if (!$this->allowShowAll) {
+            foreach ($default_category as $lang => $cat) {
+                if (!in_array($cat, $categories[$lang], true)) {
+                    $default_category[$lang] = $categories[$lang][0];
+                }
+            }
+        }
         $this->default_category = $default_category;
 
         if (!isset($products) || !is_array($products)) {

--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -60,7 +60,7 @@ abstract class Controller
             define('XHS_URL', $this->settings['url']);
         }
         $this->bridge = new CmsBridge();
-        $this->catalog = new Catalogue(XHS_URI_SEPARATOR, $this->version);
+        $this->catalog = new Catalogue(XHS_URI_SEPARATOR, $this->version, $this->settings['allow_show_all']);
         if (!class_exists('XH_CSRFProtection')) {
             include_once "{$pth['folder']['classes']}CsrfProtection.php";
         }

--- a/templates/backend/categories.tpl
+++ b/templates/backend/categories.tpl
@@ -60,7 +60,9 @@
 	<?php $this->hint('default_product_category'); ?></p>
 	<form method="post">
 		%CSRF_TOKEN_INPUT%
+		<?php if ($this->allowShowAll){ ?>
 		<p><label><?php echo $this->radioNameValueLabel('xhsDefaultCat', $this->labels['all_categories']);?>&nbsp;<?php echo $this->label('all_categories') ?></label><br>
+		<?php } ?>
 		<?php foreach($this->categories as $category){ ?>
 		<label><?php echo $this->radioNameValueLabel('xhsDefaultCat', $category);?>&nbsp;<?php echo $category; ?></label><br>
         <?php } ?></p>


### PR DESCRIPTION
If `allow_show_all` is disabled, we change the default category to the
first available category on the fly, if the chosen default category is
not contained in the available categories.  We also make sure that we
do not show the "show all" category for the default category selection
in the category editor.