### PR TITLE
Fix #213: Catalogue physically sorted??

### DIFF
--- a/classes/Catalogue.php
+++ b/classes/Catalogue.php
@@ -57,12 +57,15 @@ class Catalogue
 
         asort($sortOrder);
 
-
         $i = 1;
         foreach (array_keys($sortOrder) as $key) {
             $products[$key]->setSortIndex($i);
             $i++;
         }
+
+        uasort($products, function (Product $productA, Product $productB) {
+            return $productA->getSortIndex() - $productB->getSortIndex();
+        });
 
         $this->products = isset($products) ? $products : array();
 

--- a/classes/Catalogue.php
+++ b/classes/Catalogue.php
@@ -248,7 +248,7 @@ class Catalogue
 
     public function addProduct(Product $product)
     {
-        $product->setSortIndex(0);
+        $product->setSortIndex(PHP_INT_MAX);
         $this->products[] = $product;
         $this->save();
     }

--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -155,9 +155,6 @@ abstract class Controller
         }
 
         $productList = $this->catalog->getProducts($category);
-        uasort($productList, function (Product $productA, Product $productB) {
-            return $productA->getSortIndex() - $productB->getSortIndex();
-        });
         $products = array();
 
         foreach ($productList as $index => $product) {


### PR DESCRIPTION
Instead of sorting the catalog after reading, we sort it on saving.
This is more efficient, and also keeps the sort order for multiple
products on the same custom product page.