### PR TITLE
Fix #192: Add to cart fails miserably when Cookies are disabled

### DIFF
--- a/index.php
+++ b/index.php
@@ -61,7 +61,11 @@ if ($xhsController instanceof FrontEndController
     && !$edit) {
     if (isset($_POST['xhsTask'])) {
         if ($_POST['xhsTask'] == 'updateCart') {
-            $xhsController->updateCart();
+            if (empty($_COOKIE)) {
+                $o .= XH_message('info', $plugin_tx['xhshop']['message_no_cookie']);
+            } else {
+                $xhsController->updateCart();
+            }
         }
     }
 

--- a/languages/de.php
+++ b/languages/de.php
@@ -179,6 +179,7 @@ $plugin_tx['xhshop']['hints_price_info_no_vat']="MwSt. wird nach § 19 UStG. nic
 $plugin_tx['xhshop']['labels_cat_select'] = 'Kategorie-Auswahl';
 
 $plugin_tx['xhshop']['message_backup_created']="Sicherung %s angelegt";
+$plugin_tx['xhshop']['message_no_cookie']="Um Einkaufen zu können, muss Ihr Browser Sitzungs-Cookies erlauben!";
 
 $plugin_tx['xhshop']['cash-in-advance_label']="Vorkasse";
 $plugin_tx['xhshop']['cash-on-delivery_label']="Nachnahme";

--- a/languages/en.php
+++ b/languages/en.php
@@ -179,6 +179,7 @@ $plugin_tx['xhshop']['hints_price_info_no_vat']="no taxes";
 $plugin_tx['xhshop']['labels_cat_select'] = 'Select Category';
 
 $plugin_tx['xhshop']['message_backup_created']="Backup %s created";
+$plugin_tx['xhshop']['message_no_cookie']="For shopping, your browser needs to allow session cookies!";
 
 $plugin_tx['xhshop']['cash-in-advance_label']="Cash in Advance";
 $plugin_tx['xhshop']['cash-on-delivery_label']="Cash on Delivery";


### PR DESCRIPTION
We check whether any cookies are set when a product is added to the
cart, and show an message that cookies need to be enabled, if not.