### PR TITLE
Close #201: Don't show CoS and shipping costs in print view

### DIFF
--- a/classes/FrontEndView.php
+++ b/classes/FrontEndView.php
@@ -161,7 +161,11 @@ class FrontEndView extends View
     public function linkedPageHint($url, $text)
     {
         if ($url) {
-            $starttag = sprintf('<a href="%s&print" class="zoom_i xhsCosLnk" target="_blank">', $url);
+            if (in_array('hi_fancybox', XH_plugins(), true)) {
+                $starttag = sprintf('<a href="%s&print" class="zoom_i xhsCosLnk" target="_blank">', $url);
+            } else {
+                $starttag = sprintf('<a href="%s" class="xhsCosLnk">', $url);
+            }
             $endtag = '</a>';
         } else {
             $starttag = $endtag = '';


### PR DESCRIPTION
If hi_fancybox is not enabled, we link to the full page view in the
same browser window/tab.