### PR TITLE
Adopt Phan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         run: cd cmsimplexh/plugins/xhshop && composer install
       - name: phing sniff
         run: cd cmsimplexh/plugins/xhshop && PATH=vendor/bin:$PATH phing sniff
+      - name: phing phan
+        run: cd cmsimplexh/plugins/xhshop && PATH=vendor/bin:$PATH phing phan
       - name: phing mess
         run: cd cmsimplexh/plugins/xhshop && PATH=vendor/bin:$PATH phing mess
       - name: phing unit-tests

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+    'directory_list' => [
+        "classes",
+        "phpmailer",
+        "../../cmsimple",
+        "../fa/classes",
+    ],
+    'file_list' => [
+        "admin.php",
+        "index.php",
+    ],
+    'exclude_analysis_directory_list' => [
+        "phpmailer",
+        "../../cmsimple",
+        "../fa/classes",
+    ],
+    'minimum_severity' => 10,
+];

--- a/build.xml
+++ b/build.xml
@@ -42,6 +42,12 @@
         </exec>
     </target>
 
+    <target name="phan" description="run static analysis">
+        <exec executable="phan" passthru="true" checkreturn="true">
+            <arg value="--color"/>
+        </exec>
+    </target>
+
     <target name="mess" description="detects code flaws">
         <phpmd rulesets="codesize,unusedcode">
             <fileset refid="php-sources"/>
@@ -91,6 +97,7 @@
         <mkdir dir="dist/content/xhshop/tmp_orders"/>
         <move todir="dist/plugins/xhshop">
             <fileset dir="export">
+                <exclude name=".phan"/>
                 <exclude name="build.xml"/>
                 <exclude name="composer.*"/>
                 <exclude name="coverage.xml"/>

--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -67,9 +67,7 @@ abstract class Controller
         if (!class_exists('XH_CSRFProtection')) {
             include_once "{$pth['folder']['classes']}CsrfProtection.php";
         }
-        $this->csrfProtector = isset($_XH_csrfProtection) ?
-            $_XH_csrfProtection :
-            new CSRFProtection('xhs_csrf_token');
+        $this->csrfProtector = isset($_XH_csrfProtection) ? $_XH_csrfProtection : new CSRFProtection('xhs_csrf_token');
 
         $viewProvider = preg_replace('/Controller$/', 'View', get_class($this));
         $this->viewProvider = new $viewProvider();

--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -2,7 +2,7 @@
 
 namespace Xhshop;
 
-use XH_CSRFProtection;
+use XH\CSRFProtection;
 
 abstract class Controller
 {
@@ -17,7 +17,7 @@ abstract class Controller
     protected $shopIsOn1stPage;
 
     /**
-     * @var CsrfProtection
+     * @var CSRFProtection
      */
     protected $csrfProtector;
 
@@ -56,7 +56,7 @@ abstract class Controller
         /**
          * TODO: eliminate need of that CMSimple-separator, leave it to the bridge
          */
-         
+
          $this->shopIsOn1stPage = !XH_ADM && $this->settings['url'] === $u[$xh_publisher->getFirstPublishedPage()];
 
         if (!defined('XHS_URL') && isset($this->settings['url'])) {
@@ -69,7 +69,7 @@ abstract class Controller
         }
         $this->csrfProtector = isset($_XH_csrfProtection) ?
             $_XH_csrfProtection :
-            new XH_CSRFProtection('xhs_csrf_token');
+            new CSRFProtection('xhs_csrf_token');
 
         $viewProvider = preg_replace('/Controller$/', 'View', get_class($this));
         $this->viewProvider = new $viewProvider();
@@ -393,5 +393,5 @@ abstract class Controller
     public function isShopOn1stPage()
     {
         return $this->shopIsOn1stPage;
-    }
+}
 }

--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -391,5 +391,5 @@ abstract class Controller
     public function isShopOn1stPage()
     {
         return $this->shopIsOn1stPage;
-}
+    }
 }

--- a/classes/FrontEndController.php
+++ b/classes/FrontEndController.php
@@ -4,6 +4,7 @@ namespace Xhshop;
 
 use RuntimeException;
 use PHPMailer\PHPMailer\PHPMailer;
+use Xhshop\Payment\Paypal;
 
 class FrontEndController extends Controller
 {
@@ -763,6 +764,7 @@ class FrontEndController extends Controller
     {
         if (isset($_GET['xhsIpn'])) {
             $this->loadPaymentModule('paypal');
+            assert($this->paymentModules['paypal'] instanceof Paypal);
             $this->paymentModules['paypal']->ipn();
         }
         $ok = !$this->hasSystemCheckFailure();

--- a/classes/SystemCheckService.php
+++ b/classes/SystemCheckService.php
@@ -45,7 +45,7 @@ class SystemCheckService
             $this->checkExtension('json'),
             $this->checkExtension('mbstring'),
             $this->checkExtension('session'),
-            $this->checkXhVersion('1.6.3'),
+            $this->checkXhVersion('1.7.0'),
             $this->checkPlugin('fa'),
             $this->checkWritability("$this->pluginFolder/css/"),
             $this->checkWritability("$this->pluginFolder/config/"),

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "require-dev": {
         "phing/phing": "2.17.*",
         "squizlabs/php_codesniffer": "3.7.*",
+        "phan/phan": "5.4.*",
         "phpmd/phpmd": "2.6.*",
         "phpunit/phpunit": "9.5.*",
         "mikey179/vfsstream": "1.6.*",

--- a/help/help.htm
+++ b/help/help.htm
@@ -18,7 +18,7 @@
 		<section id="requirements">
 			<h2>Voraussetzungen</h2>
 			<ul>
-				<li>CMSimple_XH ≥ 1.6.3</li>
+				<li>CMSimple_XH ≥ 1.7.0</li>
 				<li>PHP ≥ 5.5.0</li>
 				<li>Plugin <a href="http://3-magi.net/?CMSimple_XH/Fa_XH" target="_blank">FA_XH</a> (ist ab CMSimple_XH 1.7 schon dabei)</li>
 				<li>Plugin <a href="http://cmsimple.holgerirmler.de/?Plugins:FancyBox_f%26uuml%3Br_CMSimple" target="_blank">FancyBox</a> wird empfohlen &#8211; der Shop funktioniert aber auch ohne.</li>


### PR DESCRIPTION
A static analyzer helps to detect some potential issues without even
running the code.  Phan appears to be particularly suitable for
seriously legacy code.  For now we configure it to report critical
issues only.

~~To avoid the dependency hell, we don't add it as composer development
requirement, but rather introduce Phive.~~

We also run the Phing target `phan` for CI.

Note that this raises the requirement to CMSimple_XH ≥ 1.7.0, since
earlier versions didn't use namespaced classes (and working around that
doesn't seem sensible).